### PR TITLE
Cmdline arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ in main.c. Then compile with `make` in the terminal.
 Running
 =======
 
-Run by typing `./bedrock-proxy` into the terminal on your main device. Both the
-Xbox and the device running this need to be on the same network. You should find
-the server you want in the Minecraft Friends section under LAN Games.
+Run the program itself with `./bedrock-proxy <server-address> <server-port> <max
+_clients> <timeout>` into the terminal on your main device. Server address and port
+arguments are required. Max clients and timeout(in seconds) arguments are optional
+and default to 40 and 15 respectively.
+
+Both the Xbox and the device running this need to be on the same network. You
+should find the server you want in the Minecraft Friends section under LAN Games.
 
 I have included an example systemd service file to start this automatically at boot
 for any Linux users of systemd.

--- a/bedrock-proxy.service
+++ b/bedrock-proxy.service
@@ -7,7 +7,7 @@ Type=simple
 Restart=always
 RestartSec=5
 User=nobody
-ExecStart=/usr/local/bin/bedrock-proxy
+ExecStart=/usr/local/bin/bedrock-proxy exampleserver.com 19132
 Nice=-2
 
 [Install]

--- a/main.c
+++ b/main.c
@@ -1,17 +1,39 @@
-
 #include <stdio.h>
+#include <stdint.h>
 #include "proxy.h"
 
 #define MAX_CLIENTS 40
 #define TIMEOUT 15 // seconds
 #define CLIENT_PORT 19132 // port that the Xbox One attempts to connect to, do not change
-#define SERVER_PORT 19132
-#define SERVER_ADDR "exampleserver.com"
 
 int main(int argc, char* argv[]) {
-  int ret;
+  int ret, timeout, max_clients;
+  uint32_t server_port;
 
-  ret = start_proxy(CLIENT_PORT, SERVER_PORT, SERVER_ADDR, TIMEOUT, MAX_CLIENTS, NULL, NULL);
+  if(argc < 3){
+    printf("Not enough arguments supplied.\nUsage:\nbedrock-proxy <server-address> <server-port> <max_clients> <timeout>\nServer address and port arguments are required.\nMax clients and timeout(in seconds) arguments are optional and default to 40 and 15 respectively.\nExample:\nbedrock-proxy exampleserver.com 19132\n");
+    return(0);
+  }
+  else if(argc == 3) {
+    server_port = (unsigned)atoi(argv[2]);
+    max_clients = MAX_CLIENTS;
+    timeout = TIMEOUT;
+  }
+  else if(argc == 4) {
+    server_port = (unsigned)atoi(argv[2]);
+    max_clients = atoi(argv[3]);
+    timeout = TIMEOUT;
+  }
+  else if(argc == 5) {
+    server_port = (unsigned)atoi(argv[2]);
+    max_clients = atoi(argv[3]);
+    timeout = atoi(argv[4]);
+  }
+  else {
+    printf("Too many arguments supplied.\n");
+    return(0);
+  }
+  ret = start_proxy(CLIENT_PORT, server_port, argv[1], timeout, max_clients, NULL, NULL);
   if(ret) {
     printf("Error! %i\n", ret);
   }


### PR DESCRIPTION
As promised, pull request for supporting command line arguments, so the user doesn't need to compile the program again every time they wish to proxy a new server.

Usage: 
`bedrock-proxy <server-address> <server-port> <max_clients> <timeout>`
Server address and port arguments are required. Max clients and timeout(in seconds) arguments are optional and default to 40 and 15 respectively.